### PR TITLE
Default to an empty entity when the node cannot be found.

### DIFF
--- a/reclass/storage/yaml_fs/__init__.py
+++ b/reclass/storage/yaml_fs/__init__.py
@@ -8,6 +8,7 @@
 #
 import os, sys
 import fnmatch
+from reclass import datatypes
 from reclass.storage import NodeStorageBase
 from yamlfile import YamlFile
 from directory import Directory
@@ -63,7 +64,10 @@ class ExternalNodeStorage(NodeStorageBase):
             path = os.path.join(self.nodes_uri, relpath)
             name = os.path.splitext(relpath)[0]
         except KeyError, e:
-            raise reclass.errors.NodeNotFound(self.name, name, self.nodes_uri)
+            # There is no node configuration file found, so return an empty
+            # entity. This allows class mappings to work on nodes without a
+            # specific configuration file.
+            return datatypes.Entity(name=name, environment=self._default_environment)
         entity = YamlFile(path).get_entity(name, self._default_environment)
         return entity
 


### PR DESCRIPTION
This allows the class_mapping functionality to run on nodes that don't
have (or need) their own node configuration file. So for example, if a
node isn't explicitly configured and you have a 'default' rule in your
class mapping, then it will run for all nodes, not just those that are
explicitly configured.

In my opinion this makes the class_mapping a much more powerful feature, as it allows you to fully configure a node based on regular expressions in the class mapping.
I have a feeling that maybe this should be configurable, so you can enable it and disable it, however I'm not certain how to go about doing that.

Any suggestions & comments would be nice. If this is a stupid idea and you know of another way to accomplish the same result, that would be awesome!
