### PR TITLE
wrong variable used in the example of using reclass with salt

### DIFF
--- a/doc/source/salt.rst
+++ b/doc/source/salt.rst
@@ -54,7 +54,7 @@ following steps have already been prepared.
    ``$HOME/reclass-config.yml``::
 
       storage_type: yaml_fs
-      base_inventory_uri: /srv/reclass
+      inventory_base_uri: /srv/reclass
 
    Or you can reuse the first entry of ``file_roots`` under ``base`` in the Salt
    master config.


### PR DESCRIPTION
I found out that the documentation has the following error on the page about using reclass with salt: the correct variable is **inventory_base_uri** and not base_inventory_uri.