### PR TITLE
Fixed NameError in InvalidClassnameError

### DIFF
--- a/reclass/errors.py
+++ b/reclass/errors.py
@@ -195,7 +195,7 @@ class InvalidClassnameError(NameError):
 
     def _get_message(self):
         msg = "Invalid character '{0}' in class name '{1}'."
-        return msg.format(self._char, classname)
+        return msg.format(self._char, self._classname)
 
 
 class DuplicateNodeNameError(NameError):


### PR DESCRIPTION
When specifying an invalid class name (e.g. a slash), an InvalidClassnameError is thrown. This error class currently throws an error itself though:

```
Traceback (most recent call last):
  File "/usr/local/bin/reclass", line 11, in <module>
    load_entry_point('reclass', 'console_scripts', 'reclass')()
  File "/opt/reclass/reclass/cli.py", line 43, in main
    e.exit_with_message(sys.stderr)
  File "/opt/reclass/reclass/errors.py", line 33, in exit_with_message
    print >>out, self.message
  File "/opt/reclass/reclass/errors.py", line 23, in <lambda>
    message = property(lambda self: self._get_message())
  File "/opt/reclass/reclass/errors.py", line 198, in _get_message
    return msg.format(self._char, classname)
NameError: global name 'classname' is not defined
```

This can be easily fixed by using **self._classname** instead of **classname**, as you can see within this pull request.