### PR TITLE
Fix `reclass` in example code

### DIFF
--- a/doc/source/salt.rst
+++ b/doc/source/salt.rst
@@ -43,7 +43,7 @@ following steps have already been prepared.
 
    It's handy to symlink |reclass|' Salt adapter itself to that directory::
 
-      $ ln -s /usr/share/reclass/reclass-salt /srv/salt/states/reclass
+      $ ln -s /usr/share/reclass/reclass-salt /srv/salt/reclass
 
    As you can now just inspect the data right there from the command line::
 


### PR DESCRIPTION
It caused the following error with original example

```
vagrant@saltmaster:/srv/salt/states$ ./reclass --top
No such directory: /srv/salt/states/nodes
None
```