### PR TITLE
Unescape reference names during interpolation/resolution

### DIFF
--- a/reclass/utils/dictpath.py
+++ b/reclass/utils/dictpath.py
@@ -103,7 +103,7 @@ class DictPath(object):
             if isinstance(container, (list, tuple)):
                 container = container[int(i)]
             else:
-                container = container[i]
+                container = container[self._unescape_string(i)]
         return container
 
     def _split_string(self, string):
@@ -111,6 +111,9 @@ class DictPath(object):
 
     def _escape_string(self, string):
         return string.replace(self._delim, '\\' + self._delim)
+
+    def _unescape_string(self, string):
+        return string.replace('\\' + self._delim, self._delim)
 
     def new_subpath(self, key):
         try:


### PR DESCRIPTION
Reclass uses the syntax ${foo:bar} to access the parameter foo[bar].
This means that parameter names including ':' needed it to be escaped,
but for that to work, the name needs to be unescaped again before being
lookup up. Which is what this patch does.

Signed-off-by: martin f. krafft <madduck@madduck.net>